### PR TITLE
Rule changes to deal with widgets without resName

### DIFF
--- a/android-core/src/main/kotlin/org/mint/android/rule/BasicRules.kt
+++ b/android-core/src/main/kotlin/org/mint/android/rule/BasicRules.kt
@@ -15,7 +15,7 @@ object BasicRules {
 
     val defaultPrio = { _: AndroidState -> BigDecimal(1) }
     private val viewTag: (AndroidState) -> String = { s -> (s.node as Element).getAttribute("tag") }
-    private val positionInViewHierarchy: (AndroidState) -> String =
+    val positionInViewHierarchy: (AndroidState) -> String =
         { s -> (s.node as Element).getAttribute("positionInViewHierarchy") }
 
     fun fprio(p: BigDecimal) = { _: AndroidState -> p }

--- a/android-core/src/main/kotlin/org/mint/android/rule/input/InputRules.kt
+++ b/android-core/src/main/kotlin/org/mint/android/rule/input/InputRules.kt
@@ -68,10 +68,10 @@ object InputRules {
     private const val standardEditTextPredicate = " @isEditText = 'true' and @isDisplayed = 'true' " +
         "and @hasOnClickListeners = 'false'"
 
-    fun defaultUTF8InputRule(): GenericInputRule =
-        GenericInputRule(
+    fun defaultUTF8InputRule(): PositionBasedInputRule =
+        PositionBasedInputRule(
             description = "Generate UTF8 text streams for anything accepting text",
-            pred = BasicRules.xpred(".[@isEditText='true']"),
+            pred = BasicRules.xpred(".[$standardEditTextPredicate]"),
             prio = BasicRules.defaultPrio,
             gen = {
                 it.selectOneOf(
@@ -82,11 +82,12 @@ object InputRules {
                         )
                     )
                 )
-            }
+            },
+            itemPosition = BasicRules.positionInViewHierarchy
         )
 
-    fun defaultTextInputRule(): GenericInputRule =
-        GenericInputRule(
+    fun defaultTextInputRule(): PositionBasedInputRule =
+        PositionBasedInputRule(
             description = "Generate generic text for anything accepting text",
             pred = BasicRules.xpred(
                 ".[" +
@@ -94,11 +95,12 @@ object InputRules {
                     " and number(@inputType) = $INPUT_TYPE_TEXT or number(@inputType) = $INPUT_TYPE_TEXT_PASSWORD ]"
             ),
             prio = BasicRules.defaultPrio,
-            gen = rgen("([A-Za-z ]{5,20}|([A-Za-z0-9 ]{5,20})|([0-9]{1,5})")
+            gen = rgen("([A-Za-z ]{5,20}|([A-Za-z0-9 ]{5,20})|([0-9]{1,5})"),
+            itemPosition = BasicRules.positionInViewHierarchy
         )
 
-    fun defaultMultilineTextInputRule(): GenericInputRule =
-        GenericInputRule(
+    fun defaultMultilineTextInputRule(): PositionBasedInputRule =
+        PositionBasedInputRule(
             description = "Generate generic text for anything accepting text",
             pred = BasicRules.xpred(
                 ".[" +
@@ -106,7 +108,8 @@ object InputRules {
                     "and number(@inputType) = $INPUT_TYPE_TEXT_MULTILINE ]"
             ),
             prio = BasicRules.defaultPrio,
-            gen = rgen("([A-Za-z \\n]{5,40}|([A-Za-z0-9 \\n]{5,40})|([0-9]{1,5})")
+            gen = rgen("([A-Za-z \\n]{5,40}|([A-Za-z0-9 \\n]{5,40})|([0-9]{1,5})"),
+            itemPosition = BasicRules.positionInViewHierarchy
         )
 
     fun defaultEmailAddressInputRule(): GenericInputRule =
@@ -243,12 +246,13 @@ object InputRules {
         )
 
     // for input types & combinations not covered by the more specific rules
-    fun defaultGenericTextInputRule(): GenericInputRule =
-        GenericInputRule(
+    fun defaultGenericTextInputRule(): PositionBasedInputRule =
+        PositionBasedInputRule(
             description = "Generate generic text for anything accepting any type of input",
             pred = BasicRules.xpred(".[$standardEditTextPredicate]"),
             prio = BasicRules.fprio(BigDecimal(0.5)),
-            gen = rgen("([A-Za-z ]{5,20}|([A-Za-z0-9 ]{5,20})|([0-9]{1,5})")
+            gen = rgen("([A-Za-z ]{5,20}|([A-Za-z0-9 ]{5,20})|([0-9]{1,5})"),
+            itemPosition = BasicRules.positionInViewHierarchy
         )
 
     fun defaultUneditableTextClickDeprioritizeRule(): MultiplicativeRule =

--- a/android-core/src/main/kotlin/org/mint/android/rule/input/PositionBasedInputRule.kt
+++ b/android-core/src/main/kotlin/org/mint/android/rule/input/PositionBasedInputRule.kt
@@ -1,0 +1,26 @@
+package org.mint.android.rule.input
+
+import org.mint.android.Action
+import org.mint.android.AndroidConstants
+import org.mint.android.AndroidState
+import org.w3c.dom.Element
+import java.math.BigDecimal
+
+data class PositionBasedInputRule(override val description: String,
+                                  val pred: (AndroidState) -> Boolean,
+                                  val prio: (AndroidState) -> BigDecimal,
+                                  val gen: (AndroidState) -> String,
+                                  val itemPosition: (AndroidState) -> String) : BaseInputRule() {
+    override val action: Action = Action.INPUT
+    override fun generate(): (AndroidState) -> String = gen
+    override fun priority(): (AndroidState) -> BigDecimal = prio
+    override fun predicate(): (AndroidState) -> Boolean = pred
+
+    private fun itemPosition(): (AndroidState) -> String = itemPosition
+
+    override fun attributes(state: AndroidState, action: Element) {
+        super.attributes(state, action)
+        action.setAttribute(AndroidConstants.POSITION, itemPosition()(state))
+    }
+
+}

--- a/android-core/src/main/kotlin/org/mint/android/rule/viewgroup/AdapterViewRules.kt
+++ b/android-core/src/main/kotlin/org/mint/android/rule/viewgroup/AdapterViewRules.kt
@@ -53,6 +53,7 @@ object AdapterViewRules {
                     "and @isClickable = 'true' " +
                     "and @isAdapterView = 'true' " +
                     "and not(@isSpinner = 'true') " +
+                    "and @resourceName" +
                     "]"
             ),
             itemPosition = randomPositionInList,

--- a/espresso-runner/src/main/kotlin/org/mint/espressoRunner/EspressoLoop.kt
+++ b/espresso-runner/src/main/kotlin/org/mint/espressoRunner/EspressoLoop.kt
@@ -4,6 +4,7 @@ import android.app.Instrumentation.ActivityResult
 import androidx.fragment.app.FragmentActivity.RESULT_OK
 import androidx.test.espresso.Espresso.onData
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.action.ViewActions.clearText
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.closeSoftKeyboard
@@ -17,6 +18,7 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.isInternal
 import androidx.test.espresso.matcher.RootMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withResourceName
 import androidx.test.espresso.matcher.ViewMatchers.withTagValue
+import com.google.common.base.Strings
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.anything
 import org.hamcrest.Matchers.hasToString
@@ -157,11 +159,17 @@ data class EspressoLoop(private val _ctx: AndroidCtx, private val seq: String, p
             }
             Action.INPUT.tagName -> {
                 val input = n.getAttribute("text")
+                val position = n.getAttribute("position")
+                val target: ViewInteraction = if (!Strings.isNullOrEmpty(position)) {
+                    onView(ViewAtPosition(position))
+                } else {
+                    view
+                }
                 if (isTypeableRegex.matches(input)) {
-                    view.perform(clearText(), typeText(input), closeSoftKeyboard())
+                    target.perform(clearText(), typeText(input), closeSoftKeyboard())
                 } else {
                     // We can't type this string on the (soft) keyboard, so just replace the existing text
-                    view.perform(replaceText(input))
+                    target.perform(replaceText(input))
                 }
             }
             Action.DATE_PICKER_INPUT.tagName -> {


### PR DESCRIPTION
Adjust input rules to include widget position and make minor predicate changes to avoid issues with widgets that are lacking the resourceName.