### PR TITLE
Fix linting issues

### DIFF
--- a/android-core/src/main/kotlin/org/mint/android/Action.kt
+++ b/android-core/src/main/kotlin/org/mint/android/Action.kt
@@ -14,5 +14,5 @@ enum class Action(val tagName: String) {
     SCROLL_TO_AND_CLICK_ITEM_AT_POSITION("scrollToAndClick"),
     TIME_PICKER_INPUT("timePickerInput"),
     DEVICE_ROTATION_CHANGE("deviceRotationChange"),
-    DEVICE_THEME_CHANGE("deviceThemeChange")
+    DEVICE_THEME_CHANGE("deviceThemeChange"),
 }

--- a/android-core/src/main/kotlin/org/mint/android/AndroidCtx.kt
+++ b/android-core/src/main/kotlin/org/mint/android/AndroidCtx.kt
@@ -27,5 +27,5 @@ data class AndroidCtxImpl(
     override val metadata: (Document, TestMetadata) -> Node,
     override val rules: Set<Rule<AndroidState>>,
     override val oracles: Set<Oracle<AndroidState>>,
-    override val applicationMonitors: Set<ApplicationMonitor<*>>
+    override val applicationMonitors: Set<ApplicationMonitor<*>>,
 ) : AndroidCtx

--- a/android-core/src/main/kotlin/org/mint/android/AndroidLoop.kt
+++ b/android-core/src/main/kotlin/org/mint/android/AndroidLoop.kt
@@ -156,7 +156,7 @@ abstract class AndroidLoop(final override val ctx: AndroidCtx, val sequence: Str
             rules.fold(state) { newState, rule ->
                 newState.apply(rule)
                 newState
-            }
+            },
         )
     }
 
@@ -206,7 +206,7 @@ abstract class AndroidLoop(final override val ctx: AndroidCtx, val sequence: Str
                 it.setAttribute(
                     AndroidConstants.ERROR_MESSAGE,
                     "Invalid SUT: No actionable items found. " +
-                        "Please check if screen has valid widgets that MINT can interact with."
+                        "Please check if screen has valid widgets that MINT can interact with.",
                 )
             }
             return Either.Left(applyAction)
@@ -220,7 +220,7 @@ abstract class AndroidLoop(final override val ctx: AndroidCtx, val sequence: Str
                 Log.e(
                     TAG,
                     "Current state unexpectedly contains multiple selected actions:\n" +
-                        AndroidStateUtils.renderXML(applyAction.node)
+                        AndroidStateUtils.renderXML(applyAction.node),
                 )
                 "Multiple actions were selected in the same step, though only one is expected"
             }

--- a/android-core/src/main/kotlin/org/mint/android/AndroidState.kt
+++ b/android-core/src/main/kotlin/org/mint/android/AndroidState.kt
@@ -82,8 +82,8 @@ data class AndroidState(val node: Node, val rnd: java.util.Random) : SUTState<An
     /** Generate a cryptographic hash in base36 representing the identity of the AndroidState, resulting in a stable naming scheme */
     fun filenameHash(): String = AndroidStateUtils.toBase36(
         AndroidStateUtils.hash(
-            AndroidStateUtils.renderXML(node).encodeToByteArray()
-        )
+            AndroidStateUtils.renderXML(node).encodeToByteArray(),
+        ),
     )
 
     /** Create an element related to the owner document of the this state. It is not attached to the document */

--- a/android-core/src/main/kotlin/org/mint/android/StoreInExternalStorage.kt
+++ b/android-core/src/main/kotlin/org/mint/android/StoreInExternalStorage.kt
@@ -10,15 +10,15 @@ import java.util.*
 object StoreInExternalStorage {
     fun mintFolder() = File(
         InstrumentationRegistry.getInstrumentation().targetContext.getExternalFilesDir(
-            Environment.DIRECTORY_DOCUMENTS
+            Environment.DIRECTORY_DOCUMENTS,
         ),
-        "mint"
+        "mint",
     )
 
     fun apply(
         repo: StateRepository<AndroidState>,
         reportID: String = UUID.randomUUID().toString(),
-        target: File = mintFolder()
+        target: File = mintFolder(),
     ): File {
         val states = repo.query(AnyQuery)
 

--- a/android-core/src/main/kotlin/org/mint/android/TestMetadata.kt
+++ b/android-core/src/main/kotlin/org/mint/android/TestMetadata.kt
@@ -3,5 +3,5 @@ package org.mint.android
 class TestMetadata(
     var className: String,
     var methodName: String,
-    var id: String
+    var id: String,
 )

--- a/android-core/src/main/kotlin/org/mint/android/oracle/AndroidDeviceOracle.kt
+++ b/android-core/src/main/kotlin/org/mint/android/oracle/AndroidDeviceOracle.kt
@@ -16,7 +16,7 @@ class AndroidDeviceOracle : Oracle<AndroidState> {
 
         val CATEGORIES: Set<OracleCategory> = setOf(
             OracleCategory.STABILITY,
-            OracleCategory.PERFORMANCE
+            OracleCategory.PERFORMANCE,
         )
     }
 
@@ -26,7 +26,7 @@ class AndroidDeviceOracle : Oracle<AndroidState> {
     override val categories: Set<OracleCategory> = CATEGORIES
 
     override fun probes(): Set<Class<out Probe<AndroidState>>> = setOf(
-        CPUProbe::class.javaObjectType
+        CPUProbe::class.javaObjectType,
     )
 
     override fun eval(state: AndroidState): AndroidState = runBlocking {

--- a/android-core/src/main/kotlin/org/mint/android/oracle/AndroidLogOracle.kt
+++ b/android-core/src/main/kotlin/org/mint/android/oracle/AndroidLogOracle.kt
@@ -21,7 +21,7 @@ class AndroidLogOracle : Oracle<AndroidState> {
         const val description: String = "An oracle that considers the Android (system) log"
         val categories: Set<OracleCategory> = setOf(
             OracleCategory.STABILITY, // Most (error) log entries are about crashes
-            OracleCategory.PERFORMANCE // Some log entries complain about slow render times
+            OracleCategory.PERFORMANCE, // Some log entries complain about slow render times
         )
         const val decision = "decision"
         const val verdict = "verdict"
@@ -32,7 +32,7 @@ class AndroidLogOracle : Oracle<AndroidState> {
     override val categories: Set<OracleCategory> = AndroidLogOracle.categories
 
     override fun probes(): Set<Class<out Probe<AndroidState>>> = setOf(
-        LogCatProbe::class.javaObjectType
+        LogCatProbe::class.javaObjectType,
     )
 
     override fun eval(state: AndroidState): AndroidState = runBlocking {

--- a/android-core/src/main/kotlin/org/mint/android/oracle/CrashOracle.kt
+++ b/android-core/src/main/kotlin/org/mint/android/oracle/CrashOracle.kt
@@ -18,7 +18,7 @@ class CrashOracle : Oracle<AndroidState> {
         const val version: String = "1"
         const val description: String = "An oracle that detects app crashes"
         val categories: Set<OracleCategory> = setOf(
-            OracleCategory.STABILITY
+            OracleCategory.STABILITY,
         )
         const val decision = "decision"
         const val verdict = "verdict"

--- a/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/AccessibilityOracle.kt
+++ b/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/AccessibilityOracle.kt
@@ -41,7 +41,7 @@ abstract class AccessibilityOracle : Oracle<AndroidState> {
         val viewChecks = state.queryViewChecks()
         if (viewChecks.isEmpty()) {
             state.node.addVerdict(
-                Verdict.OK
+                Verdict.OK,
             )
         }
         viewChecks.forEach { viewCheck ->
@@ -49,17 +49,17 @@ abstract class AccessibilityOracle : Oracle<AndroidState> {
             if (viewCheck.isError()) {
                 viewNode?.addVerdict(
                     Verdict.FAIL,
-                    message = viewCheck.attribute(ATTR_MESSAGE)
+                    message = viewCheck.attribute(ATTR_MESSAGE),
                 )
             } else if (viewCheck.isWarning()) {
                 viewNode?.addVerdict(
                     Verdict.WARNING,
-                    message = viewCheck.attribute(ATTR_MESSAGE)
+                    message = viewCheck.attribute(ATTR_MESSAGE),
                 )
             } else if (viewCheck.isInfo() || viewCheck.isResolved()) {
                 viewNode?.addVerdict(
                     Verdict.INFO,
-                    message = viewCheck.attribute(ATTR_MESSAGE)
+                    message = viewCheck.attribute(ATTR_MESSAGE),
                 )
             }
         }
@@ -131,24 +131,24 @@ abstract class AccessibilityOracle : Oracle<AndroidState> {
      */
     private fun Node.addVerdict(
         verdict: Verdict,
-        message: String? = null
+        message: String? = null,
     ) {
         val verdictAttributes = mutableListOf(
-            Pair(ATTR_DECISION, verdict.name)
+            Pair(ATTR_DECISION, verdict.name),
         )
 
         message?.let { value ->
             verdictAttributes.add(
-                Pair(ATTR_MESSAGE, value)
+                Pair(ATTR_MESSAGE, value),
             )
         }
 
         appendChild(
             tagName = name,
-            namespace = AndroidConstants.ORACLE_NS
+            namespace = AndroidConstants.ORACLE_NS,
         ).appendChild(
             tagName = ELEMENT_VERDICT,
-            attributes = verdictAttributes
+            attributes = verdictAttributes,
         )
     }
 }

--- a/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/AccessibilityOracles.kt
+++ b/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/AccessibilityOracles.kt
@@ -15,6 +15,6 @@ object AccessibilityOracles {
         TextSizeCheckOracle(),
         TouchTargetSizeCheckOracle(),
         TraversalOrderCheckOracle(),
-        UnexposedTextCheckOracle()
+        UnexposedTextCheckOracle(),
     )
 }

--- a/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/ClassNameCheckOracle.kt
+++ b/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/ClassNameCheckOracle.kt
@@ -8,6 +8,6 @@ class ClassNameCheckOracle : AccessibilityOracle() {
     override val version = "1.0.0"
     override val description = "Checks that the class name is supported by accessibility services."
     override val categories = setOf(
-        OracleCategory.A11Y
+        OracleCategory.A11Y,
     )
 }

--- a/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/ClickableSpanCheckOracle.kt
+++ b/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/ClickableSpanCheckOracle.kt
@@ -11,6 +11,6 @@ class ClickableSpanCheckOracle : AccessibilityOracle() {
         "independently in a single TextView and because accessibility services were unable to " +
         "call ClickableSpan#onClick."
     override val categories = setOf(
-        OracleCategory.A11Y
+        OracleCategory.A11Y,
     )
 }

--- a/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/DuplicateClickableBoundsCheckOracle.kt
+++ b/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/DuplicateClickableBoundsCheckOracle.kt
@@ -11,6 +11,6 @@ class DuplicateClickableBoundsCheckOracle : AccessibilityOracle() {
         "container shares its bounds with a child view, that is a clear error. " +
         "This class catches that case."
     override val categories = setOf(
-        OracleCategory.A11Y
+        OracleCategory.A11Y,
     )
 }

--- a/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/DuplicateSpeakableTextCheckOracle.kt
+++ b/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/DuplicateSpeakableTextCheckOracle.kt
@@ -9,6 +9,6 @@ class DuplicateSpeakableTextCheckOracle : AccessibilityOracle() {
     override val description = "Checks if two Views in a hierarchy have the same speakable text, " +
         "which could be confusing for users."
     override val categories = setOf(
-        OracleCategory.A11Y
+        OracleCategory.A11Y,
     )
 }

--- a/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/EditableContentDescCheckOracle.kt
+++ b/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/EditableContentDescCheckOracle.kt
@@ -9,6 +9,6 @@ class EditableContentDescCheckOracle : AccessibilityOracle() {
     override val description = "Check to ensure that an editable TextView is not labeled " +
         "by a contentDescription."
     override val categories = setOf(
-        OracleCategory.A11Y
+        OracleCategory.A11Y,
     )
 }

--- a/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/ImageContrastCheckOracle.kt
+++ b/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/ImageContrastCheckOracle.kt
@@ -9,6 +9,6 @@ class ImageContrastCheckOracle : AccessibilityOracle() {
     override val description = "Check that ensures image foregrounds have sufficient " +
         "contrast against their background."
     override val categories = setOf(
-        OracleCategory.A11Y
+        OracleCategory.A11Y,
     )
 }

--- a/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/LinkPurposeUnclearCheckOracle.kt
+++ b/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/LinkPurposeUnclearCheckOracle.kt
@@ -9,6 +9,6 @@ class LinkPurposeUnclearCheckOracle : AccessibilityOracle() {
     override val description = "Check to warn about a link (ClickableSpan) " +
         "whose purpose is unclear."
     override val categories = setOf(
-        OracleCategory.A11Y
+        OracleCategory.A11Y,
     )
 }

--- a/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/RedundantDescriptionCheckOracle.kt
+++ b/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/RedundantDescriptionCheckOracle.kt
@@ -9,6 +9,6 @@ class RedundantDescriptionCheckOracle : AccessibilityOracle() {
     override val description = "Checks for speakable text that may contain redundant " +
         "or inappropriate information."
     override val categories = setOf(
-        OracleCategory.A11Y
+        OracleCategory.A11Y,
     )
 }

--- a/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/SpeakableTextPresentCheckOracle.kt
+++ b/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/SpeakableTextPresentCheckOracle.kt
@@ -8,6 +8,6 @@ class SpeakableTextPresentCheckOracle : AccessibilityOracle() {
     override val version = "1.0.0"
     override val description = "Checks that items that require speakable text have some."
     override val categories = setOf(
-        OracleCategory.A11Y
+        OracleCategory.A11Y,
     )
 }

--- a/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/TextContrastCheckOracle.kt
+++ b/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/TextContrastCheckOracle.kt
@@ -9,6 +9,6 @@ class TextContrastCheckOracle : AccessibilityOracle() {
     override val description = "Check that ensures text content has sufficient contrast " +
         "against its background."
     override val categories = setOf(
-        OracleCategory.A11Y
+        OracleCategory.A11Y,
     )
 }

--- a/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/TextSizeCheckOracle.kt
+++ b/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/TextSizeCheckOracle.kt
@@ -9,6 +9,6 @@ class TextSizeCheckOracle : AccessibilityOracle() {
     override val description = "Looks for text that may have visibility problems " +
         "related to text scaling."
     override val categories = setOf(
-        OracleCategory.A11Y
+        OracleCategory.A11Y,
     )
 }

--- a/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/TouchTargetSizeCheckOracle.kt
+++ b/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/TouchTargetSizeCheckOracle.kt
@@ -9,6 +9,6 @@ class TouchTargetSizeCheckOracle : AccessibilityOracle() {
     override val description = "Check ensuring touch targets have a minimum size, " +
         "48x48dp by default."
     override val categories = setOf(
-        OracleCategory.A11Y
+        OracleCategory.A11Y,
     )
 }

--- a/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/TraversalOrderCheckOracle.kt
+++ b/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/TraversalOrderCheckOracle.kt
@@ -9,6 +9,6 @@ class TraversalOrderCheckOracle : AccessibilityOracle() {
     override val description = "Check to detect problems in the developer specified " +
         "accessibility traversal ordering."
     override val categories = setOf(
-        OracleCategory.A11Y
+        OracleCategory.A11Y,
     )
 }

--- a/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/UnexposedTextCheckOracle.kt
+++ b/android-core/src/main/kotlin/org/mint/android/oracle/accessibility/UnexposedTextCheckOracle.kt
@@ -10,6 +10,6 @@ class UnexposedTextCheckOracle : AccessibilityOracle() {
         "Reader) from a view that might be blocked that would result to it not being read by the " +
         "Accessibility Service."
     override val categories = setOf(
-        OracleCategory.A11Y
+        OracleCategory.A11Y,
     )
 }

--- a/android-core/src/main/kotlin/org/mint/android/probe/CPUProbe.kt
+++ b/android-core/src/main/kotlin/org/mint/android/probe/CPUProbe.kt
@@ -76,7 +76,7 @@ class CPUProbe : AndroidProbe {
     override val version: String = VERSION
     override val description: String = DESCRIPTION
     override val categories: Set<ProbeCategory> = setOf(
-        ProbeTimingCategory.PRE_ACTION
+        ProbeTimingCategory.PRE_ACTION,
     )
 
     private var targetApplicationPackageName: String? = null
@@ -203,8 +203,8 @@ class CPUProbe : AndroidProbe {
                             pid = matchResult.groupValues[2].trim(),
                             packageName = matchResult.groupValues[3].trimColon(),
                             userLoad = matchResult.groupValues[4].trimPercentage(),
-                            kernelLoad = matchResult.groupValues[7].trimPercentage()
-                        )
+                            kernelLoad = matchResult.groupValues[7].trimPercentage(),
+                        ),
                     )
                 }
 
@@ -215,8 +215,8 @@ class CPUProbe : AndroidProbe {
                             pid = "",
                             packageName = matchResult.groupValues[2].trim(),
                             userLoad = matchResult.groupValues[3].trimPercentage(),
-                            kernelLoad = matchResult.groupValues[6].trimPercentage()
-                        )
+                            kernelLoad = matchResult.groupValues[6].trimPercentage(),
+                        ),
                     )
                 }
             }
@@ -257,6 +257,6 @@ class CPUProbe : AndroidProbe {
         val pid: String,
         val packageName: String,
         val userLoad: String,
-        val kernelLoad: String
+        val kernelLoad: String,
     )
 }

--- a/android-core/src/main/kotlin/org/mint/android/probe/CrashProbe.kt
+++ b/android-core/src/main/kotlin/org/mint/android/probe/CrashProbe.kt
@@ -24,7 +24,7 @@ class CrashProbe(private val applicationMonitors: Set<ApplicationMonitor<in Any>
     override val version: String = CrashProbe.version
     override val description: String = CrashProbe.description
     override val categories: Set<ProbeCategory> = setOf(
-        ProbeTimingCategory.POST_ACTION
+        ProbeTimingCategory.POST_ACTION,
     )
 
     private var throwables: List<Throwable> = listOf()

--- a/android-core/src/main/kotlin/org/mint/android/probe/LogCatProbe.kt
+++ b/android-core/src/main/kotlin/org/mint/android/probe/LogCatProbe.kt
@@ -61,7 +61,7 @@ class LogCatProbe : AndroidProbe {
                             time = it.attribute(time) ?: "",
                             level = it.attribute(level) ?: "",
                             source = it.attribute(source) ?: "",
-                            message = it.attribute(message) ?: ""
+                            message = it.attribute(message) ?: "",
                         )
                     }
             }
@@ -71,7 +71,7 @@ class LogCatProbe : AndroidProbe {
     override val version: String = LogCatProbe.version
     override val description: String = LogCatProbe.description
     override val categories: Set<ProbeCategory> = setOf(
-        ProbeTimingCategory.PRE_ACTION
+        ProbeTimingCategory.PRE_ACTION,
     )
 
     // a rather arbitrary initial default capacity, which is is bigger than the default.
@@ -154,8 +154,8 @@ class LogCatProbe : AndroidProbe {
                                 it.groupValues[2],
                                 it.groupValues[3],
                                 it.groupValues[4],
-                                it.groupValues[5]
-                            )
+                                it.groupValues[5],
+                            ),
                         )
                     }
                 }
@@ -168,7 +168,7 @@ class LogCatProbe : AndroidProbe {
         val time: String,
         val level: String,
         val source: String,
-        val message: String
+        val message: String,
     ) {
         fun isError(): Boolean =
             // All error entries

--- a/android-core/src/main/kotlin/org/mint/android/rule/BaseRule.kt
+++ b/android-core/src/main/kotlin/org/mint/android/rule/BaseRule.kt
@@ -26,7 +26,7 @@ abstract class BaseRule : AndroidConstants, RuleTools, Rule<AndroidState> {
             _action.setAttribute(AndroidConstants.PRIORITY, priority()(state).toString())
             _action.setAttribute(
                 AndroidConstants.RESOURCE_NAME,
-                state.node.getAttribute(AndroidConstants.RESOURCE_NAME)
+                state.node.getAttribute(AndroidConstants.RESOURCE_NAME),
             )
 
             attributes(state, _action)

--- a/android-core/src/main/kotlin/org/mint/android/rule/BasicRules.kt
+++ b/android-core/src/main/kotlin/org/mint/android/rule/BasicRules.kt
@@ -27,8 +27,8 @@ object BasicRules {
                 action = rule.action,
                 pred = rule.predicate(),
                 prio = xprio(
-                    "1 div (1 + count(./abstract-a:state/correlate:historical//action:${rule.action.tagName}))"
-                )
+                    "1 div (1 + count(./abstract-a:state/correlate:historical//action:${rule.action.tagName}))",
+                ),
             )
         }
 
@@ -47,7 +47,7 @@ object BasicRules {
             description = "Click on any widget that has 'isClickable' as true and is displayed",
             action = Action.CLICK,
             pred = xpred(".[@isClickable = 'true' and @isDisplayed = 'true' ]"),
-            prio = defaultPrio
+            prio = defaultPrio,
         )
 
     fun scrollingClickableRule(): PositionBasedRule =
@@ -67,10 +67,10 @@ object BasicRules {
                     // ViewPager requires a different type of scroll action
                     "and not(ancestor::*[@isViewPager = 'true' ]) " +
                     // only widgets contained by a scrollable layout can be scrolled to
-                    "and ancestor::*[@isScrollable = 'true'] ]"
+                    "and ancestor::*[@isScrollable = 'true'] ]",
             ),
             prio = defaultPrio,
-            itemPosition = positionInViewHierarchy
+            itemPosition = positionInViewHierarchy,
         )
 
     // This will only work in the case of items that have been attributed tags.
@@ -82,10 +82,10 @@ object BasicRules {
                 ".[@isDisplayed= 'true' " +
                     "and @isClickable= 'true' " +
                     "and @tag != '' " +
-                    "]"
+                    "]",
             ),
             itemTag = viewTag,
-            prio = defaultPrio
+            prio = defaultPrio,
         )
 
     fun clickableRuleBasedOnPositionInViewHierarchy(): PositionBasedRule =
@@ -96,10 +96,10 @@ object BasicRules {
                 ".[@isDisplayed= 'true' " +
                     "and @isClickable= 'true' " +
                     "and not(exists(@tag))" +
-                    "]"
+                    "]",
             ),
             itemPosition = positionInViewHierarchy,
-            prio = defaultPrio
+            prio = defaultPrio,
         )
 
     fun clickableRuleBasedOnPositionInViewHierarchyForPopupItem(): PositionBasedRule =
@@ -110,10 +110,10 @@ object BasicRules {
                 ".[@isDisplayed= 'true' " +
                     "and @isClickable= 'true' " +
                     "and ancestor::*[@isPlatformPopup = 'true']" +
-                    "]"
+                    "]",
             ),
             itemPosition = positionInViewHierarchy,
-            prio = defaultPrio
+            prio = defaultPrio,
         )
 
     fun deprioritizeClickingOnPopupItemOnCurrentRoot(): MultiplicativeRule =
@@ -124,9 +124,9 @@ object BasicRules {
                 ".[@isDisplayed= 'true' " +
                     "and @isClickable= 'true' " +
                     "and ancestor::*[@isPlatformPopup = 'true']" +
-                    "]"
+                    "]",
             ),
-            prio = fprio(BigDecimal(0.01))
+            prio = fprio(BigDecimal(0.01)),
         )
 
     fun deviceRotationRule(): GenericRule =
@@ -134,7 +134,7 @@ object BasicRules {
             description = "Change the Device Rotation to check the responsiveness of the UI.",
             action = Action.DEVICE_ROTATION_CHANGE,
             pred = xpred(".[@isDisplayed = 'true' and @class = 'com.android.internal.policy.DecorView']"),
-            prio = fprio(BigDecimal(0.05))
+            prio = fprio(BigDecimal(0.05)),
         )
 
     fun deviceThemeRule(): GenericRule =
@@ -142,6 +142,6 @@ object BasicRules {
             description = "Change the Device Theme to check the responsiveness of the UI.",
             action = Action.DEVICE_THEME_CHANGE,
             pred = xpred(".[@isDisplayed = 'true' and @class = 'com.android.internal.policy.DecorView']"),
-            prio = fprio(BigDecimal(0.05))
+            prio = fprio(BigDecimal(0.05)),
         )
 }

--- a/android-core/src/main/kotlin/org/mint/android/rule/GenericRule.kt
+++ b/android-core/src/main/kotlin/org/mint/android/rule/GenericRule.kt
@@ -8,7 +8,7 @@ data class GenericRule(
     override val description: String,
     override val action: Action,
     val pred: (AndroidState) -> Boolean,
-    val prio: (AndroidState) -> BigDecimal
+    val prio: (AndroidState) -> BigDecimal,
 ) : BaseRule() {
     override fun priority(): (AndroidState) -> BigDecimal = prio
     override fun predicate(): (AndroidState) -> Boolean = pred

--- a/android-core/src/main/kotlin/org/mint/android/rule/ItemWithTagClickRule.kt
+++ b/android-core/src/main/kotlin/org/mint/android/rule/ItemWithTagClickRule.kt
@@ -9,7 +9,7 @@ data class ItemWithTagClickRule(
     override val action: Action,
     val pred: (AndroidState) -> Boolean,
     val itemTag: (AndroidState) -> String = { "" },
-    val prio: (AndroidState) -> BigDecimal
+    val prio: (AndroidState) -> BigDecimal,
 ) : BaseItemWithTagClickRule() {
     override fun priority(): (AndroidState) -> BigDecimal = prio
     override fun predicate(): (AndroidState) -> Boolean = pred

--- a/android-core/src/main/kotlin/org/mint/android/rule/MultiplicativeRule.kt
+++ b/android-core/src/main/kotlin/org/mint/android/rule/MultiplicativeRule.kt
@@ -15,7 +15,7 @@ data class MultiplicativeRule(
     override val description: String,
     override val action: Action,
     val pred: (AndroidState) -> Boolean,
-    val prio: (AndroidState) -> BigDecimal
+    val prio: (AndroidState) -> BigDecimal,
 ) : BaseRule() {
     override fun attributes(state: AndroidState, action: Element) {
         action.setAttribute(AndroidConstants.MODIFIER, AndroidConstants.MULTIPLICATIVE)

--- a/android-core/src/main/kotlin/org/mint/android/rule/PositionBasedRule.kt
+++ b/android-core/src/main/kotlin/org/mint/android/rule/PositionBasedRule.kt
@@ -9,7 +9,7 @@ data class PositionBasedRule(
     override val action: Action,
     val pred: (AndroidState) -> Boolean,
     val itemPosition: (AndroidState) -> String,
-    val prio: (AndroidState) -> BigDecimal
+    val prio: (AndroidState) -> BigDecimal,
 ) : BasePositionBasedClickRule() {
     override fun priority(): (AndroidState) -> BigDecimal = prio
     override fun predicate(): (AndroidState) -> Boolean = pred

--- a/android-core/src/main/kotlin/org/mint/android/rule/dialog/BottomSheetRules.kt
+++ b/android-core/src/main/kotlin/org/mint/android/rule/dialog/BottomSheetRules.kt
@@ -19,9 +19,9 @@ object BottomSheetRules {
             pred = xpred(
                 ".[@isDisplayed='true' " +
                     "and @isClickable='true'] " +
-                    "and ancestor::*[@resourceName='design_bottom_sheet']"
+                    "and ancestor::*[@resourceName='design_bottom_sheet']",
             ),
             itemPosition = positionInViewHierarchy,
-            prio = BasicRules.defaultPrio
+            prio = BasicRules.defaultPrio,
         )
 }

--- a/android-core/src/main/kotlin/org/mint/android/rule/input/GenericInputRule.kt
+++ b/android-core/src/main/kotlin/org/mint/android/rule/input/GenericInputRule.kt
@@ -8,7 +8,7 @@ data class GenericInputRule(
     override val description: String,
     val pred: (AndroidState) -> Boolean,
     val prio: (AndroidState) -> BigDecimal,
-    val gen: (AndroidState) -> String
+    val gen: (AndroidState) -> String,
 ) :
     BaseInputRule() {
     override val action: Action = Action.INPUT
@@ -31,12 +31,12 @@ data class GenericInputRule(
             InputRules.defaultDateInputRule(),
             InputRules.defaultPostalAddressInputRule(),
             InputRules.defaultPhoneNumberInputRule(),
-            InputRules.defaultGenericTextInputRule()
+            InputRules.defaultGenericTextInputRule(),
         )
         val deprioritizationRules = listOf(
             InputRules.defaultTextClickAtPositionDeprioritizeRule(),
             InputRules.defaultUneditableTextClickDeprioritizeRule(),
-            InputRules.defaultTextClickDeprioritizeRule()
+            InputRules.defaultTextClickDeprioritizeRule(),
         )
     }
 }

--- a/android-core/src/main/kotlin/org/mint/android/rule/input/InputRules.kt
+++ b/android-core/src/main/kotlin/org/mint/android/rule/input/InputRules.kt
@@ -41,7 +41,7 @@ object InputRules {
         "ﾔP􌸎潮𤿷㓪ܮ񾂧𲔥󫅴ۑЦ+僑𘊣'oճ^񎡭.8畠Ҥ򻙼࠹ﺕ뻷Ƽᰧ脯",
         "٤󘳷4숓➃񡾟k𡓯ރÒ̋򅥿y⬰LۑӎOξ樲䵽Ԝ̻샽e䐎ɰ퟾󬌇ýv򄬓",
         "𥒪䔪𢂚񽖐d󷗜ᶟ񢡖𗼇򩒰򪯠󒐦ٛՄ󑽘í䀑򴚼􊂺􄘙گW򻓧Ꝋ񧆌񿒖⁢w뀯Ӄ&lt;䵖",
-        "󧓇󔰣幽Я󂖇9񳴎􋞂,ی񗛳ٸ٥lŘu[⻠sŏK]ʐ􀀛󶚠󩙲}᷼􈔌p"
+        "󧓇󔰣幽Я󂖇9񳴎􋞂,ی񗛳ٸ٥lŘu[⻠sŏK]ʐ􀀛󶚠󩙲}᷼􈔌p",
     )
 
     private val twoByteUTF8 = listOf(
@@ -49,7 +49,7 @@ object InputRules {
         "ܶؿ̰߶ՏҮȍđǮҖȔʖִŽƫǻ",
         "ސմ֌ȬƗŵިֆ݈ـŎӟůݑױǬ",
         "˘ҟӀ͍̀ߧʆђԿ̒ʲع˷ѭݢҒ",
-        "ߢІŋ߹źѩȱϻڈǶձǮ׸̀ڧܨ"
+        "ߢІŋ߹źѩȱϻڈǶձǮ׸̀ڧܨ",
     )
 
     fun rgen(r: String) = RegexInputGenerator(r)
@@ -78,12 +78,12 @@ object InputRules {
                     it.selectOneOf(
                         listOf(
                             multiByteUTF8,
-                            twoByteUTF8
-                        )
-                    )
+                            twoByteUTF8,
+                        ),
+                    ),
                 )
             },
-            itemPosition = BasicRules.positionInViewHierarchy
+            itemPosition = BasicRules.positionInViewHierarchy,
         )
 
     fun defaultTextInputRule(): PositionBasedInputRule =
@@ -92,11 +92,11 @@ object InputRules {
             pred = BasicRules.xpred(
                 ".[" +
                     standardEditTextPredicate +
-                    " and number(@inputType) = $INPUT_TYPE_TEXT or number(@inputType) = $INPUT_TYPE_TEXT_PASSWORD ]"
+                    " and number(@inputType) = $INPUT_TYPE_TEXT or number(@inputType) = $INPUT_TYPE_TEXT_PASSWORD ]",
             ),
             prio = BasicRules.defaultPrio,
             gen = rgen("([A-Za-z ]{5,20}|([A-Za-z0-9 ]{5,20})|([0-9]{1,5})"),
-            itemPosition = BasicRules.positionInViewHierarchy
+            itemPosition = BasicRules.positionInViewHierarchy,
         )
 
     fun defaultMultilineTextInputRule(): PositionBasedInputRule =
@@ -105,11 +105,11 @@ object InputRules {
             pred = BasicRules.xpred(
                 ".[" +
                     standardEditTextPredicate +
-                    "and number(@inputType) = $INPUT_TYPE_TEXT_MULTILINE ]"
+                    "and number(@inputType) = $INPUT_TYPE_TEXT_MULTILINE ]",
             ),
             prio = BasicRules.defaultPrio,
             gen = rgen("([A-Za-z \\n]{5,40}|([A-Za-z0-9 \\n]{5,40})|([0-9]{1,5})"),
-            itemPosition = BasicRules.positionInViewHierarchy
+            itemPosition = BasicRules.positionInViewHierarchy,
         )
 
     fun defaultEmailAddressInputRule(): GenericInputRule =
@@ -118,7 +118,7 @@ object InputRules {
             pred = BasicRules.xpred(
                 ".[" +
                     standardEditTextPredicate +
-                    "and number(@inputType)= $INPUT_TYPE_EMAIL_ADDRESS]"
+                    "and number(@inputType)= $INPUT_TYPE_EMAIL_ADDRESS]",
             ),
             prio = BasicRules.defaultPrio,
             gen = { s ->
@@ -129,10 +129,10 @@ object InputRules {
                         "$plantEmoji|" +
                         "[A-Za-z0-9_.-]{3,64}|" +
                         "[a-zA-Z0-9!#%+/=^`*&\$\'{|}_.~-]{3,64})" +
-                        "@[A-Za-z0-9]{3,64}\\.(nl|com|net|org|co\\.uk)"
+                        "@[A-Za-z0-9]{3,64}\\.(nl|com|net|org|co\\.uk)",
                 )
                     .invoke(s)
-            }
+            },
         )
 
     fun defaultNumberInputRule(): GenericInputRule =
@@ -141,10 +141,10 @@ object InputRules {
             pred = BasicRules.xpred(
                 ".[" +
                     standardEditTextPredicate +
-                    "and number(@inputType)= $INPUT_TYPE_NUMBER or number(@inputType) = $INPUT_TYPE_NUMBER_PASSWORD ]"
+                    "and number(@inputType)= $INPUT_TYPE_NUMBER or number(@inputType) = $INPUT_TYPE_NUMBER_PASSWORD ]",
             ),
             prio = BasicRules.defaultPrio,
-            gen = rgen("[0-9]{1,6}")
+            gen = rgen("[0-9]{1,6}"),
         )
 
     fun defaultDecimalNumberInputRule(): GenericInputRule =
@@ -153,10 +153,10 @@ object InputRules {
             pred = BasicRules.xpred(
                 ".[" +
                     standardEditTextPredicate +
-                    "and number(@inputType)= $INPUT_TYPE_NUMBER_DECIMAL]"
+                    "and number(@inputType)= $INPUT_TYPE_NUMBER_DECIMAL]",
             ),
             prio = BasicRules.defaultPrio,
-            gen = rgen("[1-9]{0,2}\\.?[0-9]{1,2}|0?\\.[0-9]{1,4}")
+            gen = rgen("[1-9]{0,2}\\.?[0-9]{1,2}|0?\\.[0-9]{1,4}"),
         )
 
     fun defaultSignedNumberInputRule(): GenericInputRule =
@@ -165,10 +165,10 @@ object InputRules {
             pred = BasicRules.xpred(
                 ".[" +
                     standardEditTextPredicate +
-                    "and number(@inputType)= $INPUT_TYPE_NUMBER_SIGNED]"
+                    "and number(@inputType)= $INPUT_TYPE_NUMBER_SIGNED]",
             ),
             prio = BasicRules.defaultPrio,
-            gen = rgen("[-+]{0,1}[1-9]{1,6}")
+            gen = rgen("[-+]{0,1}[1-9]{1,6}"),
         )
 
     fun defaultPersonNameInputRule(): GenericInputRule =
@@ -177,12 +177,12 @@ object InputRules {
             pred = BasicRules.xpred(
                 ".[" +
                     standardEditTextPredicate +
-                    "and number(@inputType)= $INPUT_TYPE_PERSON_NAME]"
+                    "and number(@inputType)= $INPUT_TYPE_PERSON_NAME]",
             ),
             prio = BasicRules.defaultPrio,
             // allows single-letter last name
             // capitalized single-letter first names can occur when using initials only
-            gen = rgen("[A-Z]{1}[a-z]{0,32} [A-Z]{1}[a-z]{0,32}")
+            gen = rgen("[A-Z]{1}[a-z]{0,32} [A-Z]{1}[a-z]{0,32}"),
         )
 
     fun defaultUriRule(): GenericInputRule =
@@ -191,10 +191,10 @@ object InputRules {
             pred = BasicRules.xpred(
                 ".[" +
                     standardEditTextPredicate +
-                    "and number(@inputType) = $INPUT_TYPE_URI]"
+                    "and number(@inputType) = $INPUT_TYPE_URI]",
             ),
             prio = BasicRules.defaultPrio,
-            gen = { "https://ing.nl" }
+            gen = { "https://ing.nl" },
         )
 
     fun defaultPhoneNumberInputRule(): GenericInputRule =
@@ -203,12 +203,12 @@ object InputRules {
             pred = BasicRules.xpred(
                 ".[" +
                     standardEditTextPredicate +
-                    "and number(@inputType) = $INPUT_TYPE_PHONE]"
+                    "and number(@inputType) = $INPUT_TYPE_PHONE]",
             ),
             prio = BasicRules.defaultPrio,
             gen = { s ->
                 Faker(locale.invoke(s)).phoneNumber().phoneNumber()
-            }
+            },
         )
 
     fun defaultPostalAddressInputRule(): GenericInputRule =
@@ -217,12 +217,12 @@ object InputRules {
             pred = BasicRules.xpred(
                 ".[" +
                     standardEditTextPredicate +
-                    "and number(@inputType) = $INPUT_TYPE_POSTAL_ADDRESS]"
+                    "and number(@inputType) = $INPUT_TYPE_POSTAL_ADDRESS]",
             ),
             prio = BasicRules.defaultPrio,
             gen = { s ->
                 Faker(locale.invoke(s)).address().zipCode()
-            }
+            },
         )
 
     fun defaultDateInputRule(): GenericInputRule =
@@ -231,10 +231,10 @@ object InputRules {
             pred = BasicRules.xpred(
                 ".[" +
                     standardEditTextPredicate +
-                    "and number(@inputType) = $INPUT_TYPE_DATE]"
+                    "and number(@inputType) = $INPUT_TYPE_DATE]",
             ),
             prio = BasicRules.fprio(BigDecimal(1)),
-            gen = { s -> DateInputSupplier.get(s.rnd, locale.invoke(s)) }
+            gen = { s -> DateInputSupplier.get(s.rnd, locale.invoke(s)) },
         )
 
     fun defaultTimeInputRule(): GenericInputRule =
@@ -242,7 +242,7 @@ object InputRules {
             description = "Generate time input for widgets accepting input as time",
             pred = BasicRules.xpred(".[" + standardEditTextPredicate + "and number(@inputType) = $INPUT_TYPE_TIME]"),
             prio = BasicRules.defaultPrio,
-            gen = { s -> TimeInputSupplier.get(s.rnd, locale.invoke(s)) }
+            gen = { s -> TimeInputSupplier.get(s.rnd, locale.invoke(s)) },
         )
 
     // for input types & combinations not covered by the more specific rules
@@ -252,7 +252,7 @@ object InputRules {
             pred = BasicRules.xpred(".[$standardEditTextPredicate]"),
             prio = BasicRules.fprio(BigDecimal(0.5)),
             gen = rgen("([A-Za-z ]{5,20}|([A-Za-z0-9 ]{5,20})|([0-9]{1,5})"),
-            itemPosition = BasicRules.positionInViewHierarchy
+            itemPosition = BasicRules.positionInViewHierarchy,
         )
 
     fun defaultUneditableTextClickDeprioritizeRule(): MultiplicativeRule =
@@ -260,7 +260,7 @@ object InputRules {
             description = "De-prioritized the input of text in text fields that are uneditable",
             action = Action.INPUT,
             pred = BasicRules.xpred(".[" + standardEditTextPredicate + "and number(@inputType) = $INPUT_TYPE_NONE]"),
-            prio = BasicRules.fprio(BigDecimal(0.1))
+            prio = BasicRules.fprio(BigDecimal(0.1)),
         )
 
     fun defaultTextClickDeprioritizeRule(): MultiplicativeRule =
@@ -268,7 +268,7 @@ object InputRules {
             description = "De-prioritized the clicking of text elements",
             action = Action.CLICK,
             pred = BasicRules.xpred(".[$standardEditTextPredicate]"),
-            prio = BasicRules.fprio(BigDecimal(0.1))
+            prio = BasicRules.fprio(BigDecimal(0.1)),
         )
 
     fun defaultTextClickAtPositionDeprioritizeRule(): MultiplicativeRule =
@@ -276,6 +276,6 @@ object InputRules {
             description = "De-prioritized the clicking of text elements",
             action = Action.CLICK_ON_ITEM_AT_POSITION,
             pred = BasicRules.xpred(".[$standardEditTextPredicate]"),
-            prio = BasicRules.fprio(BigDecimal(0.1))
+            prio = BasicRules.fprio(BigDecimal(0.1)),
         )
 }

--- a/android-core/src/main/kotlin/org/mint/android/rule/input/PositionBasedInputRule.kt
+++ b/android-core/src/main/kotlin/org/mint/android/rule/input/PositionBasedInputRule.kt
@@ -6,11 +6,13 @@ import org.mint.android.AndroidState
 import org.w3c.dom.Element
 import java.math.BigDecimal
 
-data class PositionBasedInputRule(override val description: String,
-                                  val pred: (AndroidState) -> Boolean,
-                                  val prio: (AndroidState) -> BigDecimal,
-                                  val gen: (AndroidState) -> String,
-                                  val itemPosition: (AndroidState) -> String) : BaseInputRule() {
+data class PositionBasedInputRule(
+    override val description: String,
+    val pred: (AndroidState) -> Boolean,
+    val prio: (AndroidState) -> BigDecimal,
+    val gen: (AndroidState) -> String,
+    val itemPosition: (AndroidState) -> String,
+) : BaseInputRule() {
     override val action: Action = Action.INPUT
     override fun generate(): (AndroidState) -> String = gen
     override fun priority(): (AndroidState) -> BigDecimal = prio
@@ -22,5 +24,4 @@ data class PositionBasedInputRule(override val description: String,
         super.attributes(state, action)
         action.setAttribute(AndroidConstants.POSITION, itemPosition()(state))
     }
-
 }

--- a/android-core/src/main/kotlin/org/mint/android/rule/input/datetime/DateInputSupplier.kt
+++ b/android-core/src/main/kotlin/org/mint/android/rule/input/datetime/DateInputSupplier.kt
@@ -36,7 +36,7 @@ object DateInputSupplier {
     private fun suppliers(random: Random) = listOf(
         pastDateInput(random),
         futureDateInput(random),
-        leapYearDateInput(random)
+        leapYearDateInput(random),
     )
 
     private val dateFormatter: (Locale) -> DateFormat = {
@@ -50,7 +50,7 @@ object DateInputSupplier {
         val sups = suppliers(random)
         return defaultDateFormatter.format(
             sups[random.nextInt(sups.size)]
-                .time
+                .time,
         )
     }
 
@@ -58,7 +58,7 @@ object DateInputSupplier {
         val sups = suppliers(random)
         return dateFormatter.invoke(l).format(
             sups[random.nextInt(sups.size)]
-                .time
+                .time,
         )
     }
 }

--- a/android-core/src/main/kotlin/org/mint/android/rule/input/datetime/PickerInputRule.kt
+++ b/android-core/src/main/kotlin/org/mint/android/rule/input/datetime/PickerInputRule.kt
@@ -10,7 +10,7 @@ data class PickerInputRule(
     override val action: Action,
     val pred: (AndroidState) -> Boolean,
     val prio: (AndroidState) -> BigDecimal,
-    val gen: (AndroidState) -> String
+    val gen: (AndroidState) -> String,
 ) :
     BaseInputRule() {
     override fun generate(): (AndroidState) -> String = gen

--- a/android-core/src/main/kotlin/org/mint/android/rule/input/datetime/PickerInputRules.kt
+++ b/android-core/src/main/kotlin/org/mint/android/rule/input/datetime/PickerInputRules.kt
@@ -13,10 +13,10 @@ object PickerInputRules {
             pred = BasicRules.xpred(
                 ".[@isDisplayed = 'true' " +
                     "and @isDatePicker = 'true' " +
-                    "]"
+                    "]",
             ),
             prio = BasicRules.fprio(BigDecimal(1)),
-            gen = { DateInputSupplier.get(it.rnd) }
+            gen = { DateInputSupplier.get(it.rnd) },
         )
     }
 
@@ -27,10 +27,10 @@ object PickerInputRules {
             pred = BasicRules.xpred(
                 ".[@isDisplayed = 'true' " +
                     "and @isTimePicker = 'true' " +
-                    "]"
+                    "]",
             ),
             prio = BasicRules.fprio(BigDecimal(1)),
-            gen = { TimeInputSupplier.get(it.rnd) }
+            gen = { TimeInputSupplier.get(it.rnd) },
         )
     }
 }

--- a/android-core/src/main/kotlin/org/mint/android/rule/viewgroup/AdapterViewRules.kt
+++ b/android-core/src/main/kotlin/org/mint/android/rule/viewgroup/AdapterViewRules.kt
@@ -20,7 +20,7 @@ object AdapterViewRules {
 
         do {
             newPosition = random.nextInt(
-                s.node.getAttribute("itemCount").toInt()
+                s.node.getAttribute("itemCount").toInt(),
             ).toString()
         } while (newPosition == currentlySelectedItem)
 
@@ -37,10 +37,10 @@ object AdapterViewRules {
                 ".[@isDisplayed = 'true' " +
                     "and @isClickable = 'true' " +
                     "and @isSpinner = 'true' " +
-                    "]"
+                    "]",
             ),
             itemPosition = randomPositionInList,
-            prio = fprio(BigDecimal(1))
+            prio = fprio(BigDecimal(1)),
         )
     }
 
@@ -54,10 +54,10 @@ object AdapterViewRules {
                     "and @isAdapterView = 'true' " +
                     "and not(@isSpinner = 'true') " +
                     "and @resourceName" +
-                    "]"
+                    "]",
             ),
             itemPosition = randomPositionInList,
-            prio = fprio(BigDecimal(1))
+            prio = fprio(BigDecimal(1)),
         )
     }
 
@@ -69,9 +69,9 @@ object AdapterViewRules {
                 ".[@isDisplayed = 'true' " +
                     "and @isClickable = 'true' " +
                     "and @isSpinner = 'true' " +
-                    "]"
+                    "]",
             ),
-            prio = fprio(BigDecimal(0.01))
+            prio = fprio(BigDecimal(0.01)),
         )
 
     fun adapterViewSimpleClickDeprioritizeRule(): MultiplicativeRule =
@@ -82,8 +82,8 @@ object AdapterViewRules {
                 ".[@isDisplayed = 'true' " +
                     "and @isClickable = 'true' " +
                     "and @isAdapterView = 'true' " +
-                    "]"
+                    "]",
             ),
-            prio = fprio(BigDecimal(0.01))
+            prio = fprio(BigDecimal(0.01)),
         )
 }

--- a/android-core/src/main/kotlin/org/mint/android/rule/viewgroup/ViewGroupRules.kt
+++ b/android-core/src/main/kotlin/org/mint/android/rule/viewgroup/ViewGroupRules.kt
@@ -15,9 +15,9 @@ object ViewGroupRules {
             description = "Scroll pager to the right",
             action = Action.SCROLL_PAGER_TO_RIGHT,
             pred = xpred(
-                ".[@isViewPager = 'true' and @canScrollRight = 'true' ]"
+                ".[@isViewPager = 'true' and @canScrollRight = 'true' ]",
             ),
-            prio = defaultPrio
+            prio = defaultPrio,
         )
 
     fun scrollingPagerLeftRule(): GenericRule =
@@ -25,9 +25,9 @@ object ViewGroupRules {
             description = "Scroll pager to the left",
             action = Action.SCROLL_PAGER_TO_LEFT,
             pred = xpred(
-                ".[@isViewPager = 'true' and @canScrollLeft = 'true' ]"
+                ".[@isViewPager = 'true' and @canScrollLeft = 'true' ]",
             ),
-            prio = defaultPrio
+            prio = defaultPrio,
         )
 
     // The simple click action cannot be used for widgets contained by RecyclerView or ViewPager,
@@ -38,6 +38,6 @@ object ViewGroupRules {
             description = "De-prioritized the clicking of individual RecyclerView or ViewPager items with simple click",
             action = Action.CLICK,
             pred = xpred(".[ancestor::*[@isRecyclerView = 'true'] or ancestor::*[@isViewPager = 'true'] ]"),
-            prio = BasicRules.fprio(BigDecimal(0.01))
+            prio = BasicRules.fprio(BigDecimal(0.01)),
         )
 }

--- a/android-core/src/main/kotlin/org/mint/android/xml/NodeExt.kt
+++ b/android-core/src/main/kotlin/org/mint/android/xml/NodeExt.kt
@@ -80,7 +80,7 @@ fun Node.notCorrelated(): Boolean {
 fun Node.appendChild(
     tagName: String,
     namespace: String? = null,
-    attributes: List<Pair<String, String>>? = null
+    attributes: List<Pair<String, String>>? = null,
 ): Node {
     val document = ownerDocument
 

--- a/android-core/src/main/kotlin/org/mint/android/xml/ThrowableAttributes.kt
+++ b/android-core/src/main/kotlin/org/mint/android/xml/ThrowableAttributes.kt
@@ -15,7 +15,7 @@ object ThrowableAttributes {
             .createCDATASection(
                 throwable.stackTrace
                     .take(5)
-                    .joinToString(separator = "\nat ", prefix = "at ")
+                    .joinToString(separator = "\nat ", prefix = "at "),
             )
         node.appendChild(truncatedStacktrace)
 

--- a/android-core/src/test/kotlin/org/mint/android/NaivePersistentRepositoryTest.kt
+++ b/android-core/src/test/kotlin/org/mint/android/NaivePersistentRepositoryTest.kt
@@ -94,7 +94,7 @@ class NaivePersistentRepositoryTest : StateBuilder {
         for (key in repo.inMemoryRepository.abstractState.keys) {
             assertEquals(
                 repo.inMemoryRepository.abstractState.get(key)!!.size,
-                repo2.inMemoryRepository.abstractState.get(key)!!.size
+                repo2.inMemoryRepository.abstractState.get(key)!!.size,
             )
         }
 
@@ -103,7 +103,7 @@ class NaivePersistentRepositoryTest : StateBuilder {
             for (hashKey in repo.inMemoryRepository.abstractActions.get(actionKey)!!.keys) {
                 assertEquals(
                     repo.inMemoryRepository.abstractActions.get(actionKey)!!.get(hashKey)!!.size,
-                    repo2.inMemoryRepository.abstractActions.get(actionKey)!!.get(hashKey)!!.size
+                    repo2.inMemoryRepository.abstractActions.get(actionKey)!!.get(hashKey)!!.size,
                 )
             }
         }

--- a/android-core/src/test/kotlin/org/mint/android/probe/CPUProbeTest.kt
+++ b/android-core/src/test/kotlin/org/mint/android/probe/CPUProbeTest.kt
@@ -33,7 +33,7 @@ class CPUProbeTest {
                     Assert.assertEquals("364", cpuInfo.pid)
                     Assert.assertEquals(
                         "android.hardware.bluetooth@1.1-service.sim",
-                        cpuInfo.packageName
+                        cpuInfo.packageName,
                     )
                     Assert.assertEquals("0", cpuInfo.userLoad)
                     Assert.assertEquals("6.8", cpuInfo.kernelLoad)

--- a/android-core/src/test/kotlin/org/mint/android/rule/BaseRuleTest.kt
+++ b/android-core/src/test/kotlin/org/mint/android/rule/BaseRuleTest.kt
@@ -29,7 +29,7 @@ class BaseRuleTest : StateTest() {
             description = "n/a",
             action = Action.CLICK,
             pred = ".[@class = 'does.not.exist']",
-            prio = "1.0"
+            prio = "1.0",
         )
 
         state.extendWithRuleGroups()
@@ -45,7 +45,7 @@ class BaseRuleTest : StateTest() {
             description = "n/a",
             action = Action.CLICK,
             pred = ".[@class = 'does.not.exist' or @class = 'androidx.appcompat.widget.AppCompatEditText']",
-            prio = "1.0"
+            prio = "1.0",
         )
 
         state.extendWithRuleGroups()
@@ -58,7 +58,7 @@ class BaseRuleTest : StateTest() {
     fun matchAddedAttribute() {
         val rule = object : BaseRule() {
             val activeWidgetFQNs: Set<String> = setOf(
-                "androidx.appcompat.widget.AppCompatEditText"
+                "androidx.appcompat.widget.AppCompatEditText",
             )
 
             override fun attributes(state: AndroidState, action: Element) {

--- a/android-core/src/test/kotlin/org/mint/android/rule/MultiplicativeRuleTest.kt
+++ b/android-core/src/test/kotlin/org/mint/android/rule/MultiplicativeRuleTest.kt
@@ -29,21 +29,21 @@ class MultiplicativeRuleTest : StateTest() {
                 description = "Click on any widget that has 'isClickable' as true",
                 action = Action.CLICK,
                 pred = BasicRules.xpred(".[@isClickable = 'true']"),
-                prio = BasicRules.fprio(BigDecimal(2))
+                prio = BasicRules.fprio(BigDecimal(2)),
             )
 
         val prio1 = MultiplicativeRule(
             description = "prioritize the clicking of elements",
             action = Action.CLICK,
             pred = BasicRules.xpred("."),
-            prio = BasicRules.fprio(BigDecimal(3))
+            prio = BasicRules.fprio(BigDecimal(3)),
         )
 
         val prio2 = MultiplicativeRule(
             description = "prioritize the clicking of elements",
             action = Action.CLICK,
             pred = BasicRules.xpred("."),
-            prio = BasicRules.fprio(BigDecimal(5))
+            prio = BasicRules.fprio(BigDecimal(5)),
         )
 
         state.extendWithRuleGroups()
@@ -78,7 +78,7 @@ class MultiplicativeRuleTest : StateTest() {
             <View isClickable="true"/>
           </y>
         </x>
-            """.trimIndent()
+            """.trimIndent(),
         )
         val rule = ViewGroupRules.replicatedItemSimpleClickDeprioritizeRule()
 
@@ -103,7 +103,7 @@ class MultiplicativeRuleTest : StateTest() {
                         isClickable="true"
                         isDisplayed="true">
                 </View>
-            """.trimIndent()
+            """.trimIndent(),
         )
 
         val actionRule = setOf(BasicRules.simpleClickableRule())

--- a/android-core/src/test/kotlin/org/mint/android/rule/PositionBasedRuleTest.kt
+++ b/android-core/src/test/kotlin/org/mint/android/rule/PositionBasedRuleTest.kt
@@ -43,7 +43,7 @@ class PositionBasedRuleTest : StateTest() {
             <View isClickable="true"/>
           </y>
         </x>
-            """.trimIndent()
+            """.trimIndent(),
         )
         val rule = BasicRules.clickableRuleBasedOnPositionInViewHierarchy()
 
@@ -80,7 +80,7 @@ class PositionBasedRuleTest : StateTest() {
             <View isClickable="true"/>
           </y>
         </View>
-            """.trimIndent()
+            """.trimIndent(),
         )
         val rule = BasicRules.clickableRuleBasedOnPositionInViewHierarchy()
 

--- a/android-core/src/test/kotlin/org/mint/android/rule/XQueryPredicateTest.kt
+++ b/android-core/src/test/kotlin/org/mint/android/rule/XQueryPredicateTest.kt
@@ -47,7 +47,7 @@ class XQueryPredicateTest : StateTest() {
                                 resourceName=""
                                 selected="true"/>
                      </org.mint.android.rule.GenericRule>
-            """.trimIndent()
+            """.trimIndent(),
         )
         assertTrue(XQueryPredicate("count(//action:click[@selected = 'true']) = 1").invoke(s))
     }

--- a/android-core/src/test/kotlin/org/mint/android/rule/input/AbstractRegexGenerationRuleTest.kt
+++ b/android-core/src/test/kotlin/org/mint/android/rule/input/AbstractRegexGenerationRuleTest.kt
@@ -17,7 +17,7 @@ class AbstractRegexGenerationRuleTest : StateTest() {
             description = "n/a",
             pred = ".[contains(@class, 'androidx.appcompat.widget.AppCompatEditText')]",
             prio = "1.0",
-            reg = regex
+            reg = regex,
         )
 
         state.extendWithRuleGroups()

--- a/android-core/src/test/kotlin/org/mint/android/rule/input/InputRulesTest.kt
+++ b/android-core/src/test/kotlin/org/mint/android/rule/input/InputRulesTest.kt
@@ -62,7 +62,7 @@ class InputRulesTest : StateTest() {
                 </View>
               </View>
         </View>
-            """.trimIndent()
+            """.trimIndent(),
         )
 
         s.extendWithRuleGroups()

--- a/api/src/main/kotlin/org/mint/MINT.kt
+++ b/api/src/main/kotlin/org/mint/MINT.kt
@@ -43,7 +43,7 @@ class MINT private constructor(
     private val ctx: AndroidCtx,
     private val numberOfSteps: Int,
     private val numberOfSequences: Int,
-    private val loopBuilder: (AndroidCtx, String, TestMetadata?) -> MintLoop<AndroidState>
+    private val loopBuilder: (AndroidCtx, String, TestMetadata?) -> MintLoop<AndroidState>,
 ) : MINTApi, AndroidConstants {
 
     private var currentSequence: String = ""
@@ -89,7 +89,7 @@ class MINT private constructor(
         private var rules: Set<Rule<AndroidState>> = setOf(),
         private var oracles: Set<Oracle<AndroidState>> = setOf(),
         private var loopBuilder: (AndroidCtx, String, TestMetadata?) -> MintLoop<AndroidState> = { ctx, seq, metadata -> EspressoLoop(ctx, seq, metadata) },
-        private var applicationMonitors: Set<ApplicationMonitor<*>> = setOf(EspressoFailureMonitor.instance)
+        private var applicationMonitors: Set<ApplicationMonitor<*>> = setOf(EspressoFailureMonitor.instance),
     ) {
 
         /** What state repository will be used to store application state? */
@@ -125,7 +125,7 @@ class MINT private constructor(
                 ViewGroupRules.scrollingPagerLeftRule(),
                 PickerInputRules.timePickerInputRule(),
                 PickerInputRules.datePickerInputRule(),
-                BottomSheetRules.clickableRuleBasedOnPositionInViewHierarchy()
+                BottomSheetRules.clickableRuleBasedOnPositionInViewHierarchy(),
             ) + GenericInputRule.rules +
                 GenericInputRule.deprioritizationRules
 
@@ -145,7 +145,7 @@ class MINT private constructor(
             this.oracles = this.oracles + setOf(
                 AndroidLogOracle(),
                 AndroidDeviceOracle(),
-                CrashOracle()
+                CrashOracle(),
             ) + AccessibilityOracles.all
         }
 
@@ -159,7 +159,7 @@ class MINT private constructor(
             return validateSteps().zip(
                 validateSequences(),
                 validateRules(),
-                validateOracles()
+                validateOracles(),
             ) { steps, sequences, rules, oracles ->
 
                 val cfgBuilder = { doc: Document ->
@@ -195,10 +195,10 @@ class MINT private constructor(
                             rules.map {
                                 mapOf(
                                     Pair("name", it.javaClass.canonicalName ?: "unknown"),
-                                    Pair("description", it.description)
+                                    Pair("description", it.description),
                                 )
-                            }
-                        )
+                            },
+                        ),
                     )
 
                     cfg.appendChild(
@@ -209,10 +209,10 @@ class MINT private constructor(
                                 mapOf(
                                     Pair("name", it.javaClass.canonicalName ?: "unknown"),
                                     Pair("description", it.description),
-                                    Pair("categories", it.categories.joinToString(", ") { x -> x.name })
+                                    Pair("categories", it.categories.joinToString(", ") { x -> x.name }),
                                 )
-                            }
-                        )
+                            },
+                        ),
                     )
 
                     cfg.appendChild(withItem("steps", "count", steps.toString()))
@@ -240,13 +240,13 @@ class MINT private constructor(
                     testMetadataBuilder,
                     rules,
                     oracles,
-                    applicationMonitors
+                    applicationMonitors,
                 )
                 MINT(
                     ctx,
                     steps,
                     sequences,
-                    loopBuilder
+                    loopBuilder,
                 )
             }
                 .tapLeft { e ->

--- a/api/src/main/kotlin/org/mint/MINTRule.kt
+++ b/api/src/main/kotlin/org/mint/MINTRule.kt
@@ -33,7 +33,7 @@ class MINTRule(private val mint: MINT? = org.mint.MINT.Default) : MINTApi, Exter
 
         return metadataRule.apply(
             super.apply(stmt, description),
-            description
+            description,
         )
     }
 

--- a/api/src/main/kotlin/org/mint/junit/runner/MintClassRunner.kt
+++ b/api/src/main/kotlin/org/mint/junit/runner/MintClassRunner.kt
@@ -20,7 +20,7 @@ class MintClassRunner(testClass: Class<*>?) : Suite(testClass, runners(testClass
             val l = testClass.getAnnotatedFieldValues(
                 target,
                 Rule::class.java,
-                TestRule::class.java
+                TestRule::class.java,
             ).filterIsInstance<MINTRule>().first().numberOfSequences()
 
             val testRunners: MutableList<MintTestRunner> = mutableListOf()
@@ -31,9 +31,9 @@ class MintClassRunner(testClass: Class<*>?) : Suite(testClass, runners(testClass
                         TestWithParameters(
                             "[${testClass.name}]",
                             testClass,
-                            listOf("$i")
-                        )
-                    )
+                            listOf("$i"),
+                        ),
+                    ),
                 )
             }
 

--- a/api/src/test/kotlin/org/mint/api/MintIntegrationTest.kt
+++ b/api/src/test/kotlin/org/mint/api/MintIntegrationTest.kt
@@ -38,7 +38,7 @@ class MintIntegrationTest : StateBuilder {
           <View id="a" isClickable="true" isDisplayed="true"/>
           <View id="b" isClickable="false" isDisplayed="true"/>
         </View>
-        """.trimIndent()
+        """.trimIndent(),
     )
 
     private val stepTwo: AndroidState = buildState(
@@ -48,7 +48,7 @@ class MintIntegrationTest : StateBuilder {
           <View id="a" isClickable="true" isDisplayed="true"/>
           <View id="b" isClickable="true" isDisplayed="true"/>
         </View>
-        """.trimIndent()
+        """.trimIndent(),
     )
 
     private val mint: MINT = MINT.Builder()
@@ -63,7 +63,7 @@ class MintIntegrationTest : StateBuilder {
                     .withStep(stepTwo)
                     .withInvariant(XQueryPredicate("count(//View) = 3"))
                     .withPredicate(1, XQueryPredicate("count(//action:click[@selected = 'true']) = 1"))
-                    .withPredicate(2, XQueryPredicate("count(//action:click[@selected = 'true']) = 1"))
+                    .withPredicate(2, XQueryPredicate("count(//action:click[@selected = 'true']) = 1")),
             )
         }
         .build { e -> Assert.fail(e) }!!
@@ -121,7 +121,7 @@ class MintIntegrationTest : StateBuilder {
         <View>
           <View id="a" isClickable="false" />
         </View>
-            """.trimIndent()
+            """.trimIndent(),
         )
 
         val mint = MINT.Builder()
@@ -139,9 +139,9 @@ class MintIntegrationTest : StateBuilder {
                             XQueryPredicate(
                                 "count(*:action[@message = " +
                                     "'Invalid SUT: No actionable items found. " +
-                                    "Please check if screen has valid widgets that MINT can interact with.']) = 1"
-                            )
-                        )
+                                    "Please check if screen has valid widgets that MINT can interact with.']) = 1",
+                            ),
+                        ),
                 )
             }
             .build { e -> Assert.fail(e) }!!
@@ -154,8 +154,8 @@ class MintIntegrationTest : StateBuilder {
             e.message,
             containsString(
                 "Invalid SUT: No actionable items found. " +
-                    "Please check if screen has valid widgets that MINT can interact with"
-            )
+                    "Please check if screen has valid widgets that MINT can interact with",
+            ),
         )
     }
 
@@ -167,7 +167,7 @@ class MintIntegrationTest : StateBuilder {
           <View id="a" isClickable="true" isDisplayed = "true" />
           <View id="a" isClickable="true" isDisplayed = "true" />
         </View>
-            """.trimIndent()
+            """.trimIndent(),
         )
 
         val mint = MINT.Builder()
@@ -178,7 +178,7 @@ class MintIntegrationTest : StateBuilder {
                 object : ITTestLoop(
                     builder(ctx)
                         .withStep(state)
-                        .withPredicate(1, XQueryPredicate("count(//action:click[@selected = 'true']) = 2"))
+                        .withPredicate(1, XQueryPredicate("count(//action:click[@selected = 'true']) = 2")),
                 ) {
                     override fun actionSelection(state: AndroidState): Either<AndroidState, AndroidState> {
                         state.query { it.hasNS(AndroidConstants.RULE_NS) }
@@ -198,8 +198,8 @@ class MintIntegrationTest : StateBuilder {
             "error message",
             e.message,
             containsString(
-                "Multiple actions were selected in the same step, though only one is expected"
-            )
+                "Multiple actions were selected in the same step, though only one is expected",
+            ),
         )
     }
 
@@ -240,7 +240,7 @@ class MintIntegrationTest : StateBuilder {
           <View id="a" isEditText="true" isDisplayed="true" hasOnClickListeners="false"/>
           <View id="b" isClickable="true" isDisplayed="true"/>
         </View>
-            """.trimIndent()
+            """.trimIndent(),
         )
 
         return MINT.Builder()
@@ -249,8 +249,8 @@ class MintIntegrationTest : StateBuilder {
                     description = "Generate UTF8 text streams for anything accepting text",
                     pred = BasicRules.xpred(".[@isEditText='true']"),
                     prio = BasicRules.defaultPrio,
-                    gen = { "\uD83D\uDC64" }
-                )
+                    gen = { "\uD83D\uDC64" },
+                ),
             )
             .withStateRepository(repo)
             .withOracle(NoopOracle())
@@ -260,7 +260,7 @@ class MintIntegrationTest : StateBuilder {
                     ITTestLoop
                         .builder(ctx)
                         .withStep(state)
-                        .withPredicate(1, XQueryPredicate("count(//action:input[@selected = 'true']) = 1"))
+                        .withPredicate(1, XQueryPredicate("count(//action:input[@selected = 'true']) = 1")),
                 )
             }
             .build { e -> Assert.fail(e) }!!
@@ -273,7 +273,7 @@ class MintIntegrationTest : StateBuilder {
         <View>
           <View id="a" isClickable="true" />
         </View>
-            """.trimIndent()
+            """.trimIndent(),
         )
         val am: ApplicationMonitor<Nothing> = mock()
 
@@ -286,7 +286,7 @@ class MintIntegrationTest : StateBuilder {
                 ITTestLoop(
                     ITTestLoop
                         .builder(ctx)
-                        .withStep(state)
+                        .withStep(state),
                 )
             }
             .build { e -> Assert.fail(e) }!!

--- a/api/src/test/kotlin/org/mint/api/NoopOracle.kt
+++ b/api/src/test/kotlin/org/mint/api/NoopOracle.kt
@@ -13,7 +13,7 @@ class NoopOracle : Oracle<AndroidState> {
 
         val CATEGORIES: Set<OracleCategory> = setOf(
             OracleCategory.STABILITY,
-            OracleCategory.PERFORMANCE
+            OracleCategory.PERFORMANCE,
         )
     }
 

--- a/api/src/test/kotlin/org/mint/api/XMLRepresentationBug.kt
+++ b/api/src/test/kotlin/org/mint/api/XMLRepresentationBug.kt
@@ -39,9 +39,9 @@ class XMLRepresentationBug : StateBuilder {
                     <View>
                       <View id="a" isClickable="true" isDisplayed="true"/>
                     </View>
-                                """.trimIndent()
-                            )
-                        )
+                                """.trimIndent(),
+                            ),
+                        ),
                 )
             }
             .build { e -> Assert.fail(e) }!!
@@ -76,7 +76,7 @@ class XMLRepresentationBug : StateBuilder {
 
         assertEquals(
             AndroidStateUtils.renderXML(state!!.node),
-            AndroidStateUtils.renderXML(st2.node)
+            AndroidStateUtils.renderXML(st2.node),
         )
     }
 

--- a/app/src/androidTest/kotlin/org/mint/android/state/ScreenshotTest.kt
+++ b/app/src/androidTest/kotlin/org/mint/android/state/ScreenshotTest.kt
@@ -52,7 +52,7 @@ class ScreenshotTest {
         val screenshotFolder =
             File(
                 Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES),
-                "screenshots"
+                "screenshots",
             )
         if (!screenshotFolder.exists()) {
             screenshotFolder.mkdirs()

--- a/core/src/main/kotlin/org/mint/lib/OracleCategory.kt
+++ b/core/src/main/kotlin/org/mint/lib/OracleCategory.kt
@@ -7,5 +7,5 @@ enum class OracleCategory(val description: String) {
     PERFORMANCE("Performance"),
     STABILITY("Stability"),
     AESTETHICS("Look and feel"),
-    OTHER("Miscellaneous")
+    OTHER("Miscellaneous"),
 }

--- a/core/src/main/kotlin/org/mint/lib/ProbeTimingCategory.kt
+++ b/core/src/main/kotlin/org/mint/lib/ProbeTimingCategory.kt
@@ -5,5 +5,5 @@ package org.mint.lib
  */
 enum class ProbeTimingCategory : ProbeCategory {
     PRE_ACTION,
-    POST_ACTION
+    POST_ACTION,
 }

--- a/core/src/main/kotlin/org/mint/lib/Verdict.kt
+++ b/core/src/main/kotlin/org/mint/lib/Verdict.kt
@@ -24,5 +24,5 @@ enum class Verdict {
     /**
      * No known way to process the type of information acquired.
      */
-    DONT_KNOW
+    DONT_KNOW,
 }

--- a/espresso-runner/src/main/kotlin/org/mint/espressoRunner/EspressoLoop.kt
+++ b/espresso-runner/src/main/kotlin/org/mint/espressoRunner/EspressoLoop.kt
@@ -71,7 +71,7 @@ data class EspressoLoop(private val _ctx: AndroidCtx, private val seq: String, p
             val (_, node) = EspressoStateToXML.emptySUT()
             node.setAttribute(
                 AndroidConstants.ERROR_MESSAGE,
-                "Cannot obtain the root view, no concrete state available"
+                "Cannot obtain the root view, no concrete state available",
             )
             node
         } else {
@@ -116,8 +116,8 @@ data class EspressoLoop(private val _ctx: AndroidCtx, private val seq: String, p
                 onView(
                     allOf(
                         withTagValue(hasToString(n.getAttribute("tag"))),
-                        withResourceName(n.getAttribute("resourceName"))
-                    )
+                        withResourceName(n.getAttribute("resourceName")),
+                    ),
                 ).perform(click())
             }
             Action.CLICK_ON_ITEM_AT_POSITION.tagName -> {

--- a/espresso-runner/src/main/kotlin/org/mint/espressoRunner/GetRoots.kt
+++ b/espresso-runner/src/main/kotlin/org/mint/espressoRunner/GetRoots.kt
@@ -27,7 +27,7 @@ object GetRoots : () -> List<View> {
         val subWindowRootMatchers = listOf(
             RootMatchers.isPlatformPopup(),
             RootMatchers.isDialog(),
-            RootMatchers.isSystemAlertWindow()
+            RootMatchers.isSystemAlertWindow(),
         )
         subWindowRootMatchers.forEach { subWindowRootMatcher ->
             Espresso.onView(m)

--- a/espresso-runner/src/main/kotlin/org/mint/espressoRunner/actions/CustomScrollTo.kt
+++ b/espresso-runner/src/main/kotlin/org/mint/espressoRunner/actions/CustomScrollTo.kt
@@ -26,8 +26,8 @@ class CustomScrollTo : ViewAction {
                 isAssignableFrom(ScrollView::class.java),
                 isAssignableFrom(HorizontalScrollView::class.java),
                 isAssignableFrom(ListView::class.java),
-                isAssignableFrom(NestedScrollView::class.java)
-            )
+                isAssignableFrom(NestedScrollView::class.java),
+            ),
         )
     }
 

--- a/espresso-runner/src/main/kotlin/org/mint/espressoRunner/actions/DeviceRotationChange.kt
+++ b/espresso-runner/src/main/kotlin/org/mint/espressoRunner/actions/DeviceRotationChange.kt
@@ -17,6 +17,6 @@ object DeviceRotationChange {
 
     enum class Rotation {
         PORTRAIT,
-        LANDSCAPE
+        LANDSCAPE,
     }
 }

--- a/espresso-runner/src/main/kotlin/org/mint/espressoRunner/actions/DeviceThemeChange.kt
+++ b/espresso-runner/src/main/kotlin/org/mint/espressoRunner/actions/DeviceThemeChange.kt
@@ -29,6 +29,6 @@ object DeviceThemeChange {
 
     enum class Theme {
         DARK,
-        LIGHT
+        LIGHT,
     }
 }

--- a/espresso-runner/src/main/kotlin/org/mint/espressoRunner/state/AccessibilityViewCheck.kt
+++ b/espresso-runner/src/main/kotlin/org/mint/espressoRunner/state/AccessibilityViewCheck.kt
@@ -70,8 +70,8 @@ internal object AccessibilityViewCheck {
             attributes = mutableListOf(
                 Pair(ATTR_RESULT, "${result.type}"),
                 Pair(ATTR_TYPE, result.sourceCheckClass.simpleName),
-                Pair(ATTR_MESSAGE, result.getMessage(Locale.ENGLISH).toString())
-            )
+                Pair(ATTR_MESSAGE, result.getMessage(Locale.ENGLISH).toString()),
+            ),
         )
 
         result.metadata?.let { metadata ->
@@ -80,20 +80,20 @@ internal object AccessibilityViewCheck {
     }
 
     private fun Node.appendMetadata(
-        metadata: ResultMetadata
+        metadata: ResultMetadata,
     ) {
         val attributes = ArrayList<Pair<String, String>>()
         MetadataKeys.values().forEach { key ->
             if (metadata.containsKey(key.name)) {
                 attributes.add(
-                    Pair(key.name.kebabCase(), metadata.get(key))
+                    Pair(key.name.kebabCase(), metadata.get(key)),
                 )
             }
         }
 
         appendChild(
             ATTR_METADATA,
-            attributes = attributes
+            attributes = attributes,
         )
     }
 
@@ -211,6 +211,6 @@ internal object AccessibilityViewCheck {
         KEY_UNEXPOSED_TEXT(String::class),
         KEY_UNEXPOSED_TEXTS(Array<String>::class),
         KEY_OCR_BOUNDS(String::class),
-        KEY_TEXT_DETECTED_IN_IMAGE_VIEW(String::class)
+        KEY_TEXT_DETECTED_IN_IMAGE_VIEW(String::class),
     }
 }

--- a/espresso-runner/src/main/kotlin/org/mint/espressoRunner/state/AppInfo.kt
+++ b/espresso-runner/src/main/kotlin/org/mint/espressoRunner/state/AppInfo.kt
@@ -18,7 +18,7 @@ internal object AppInfo {
             try {
                 val packageInfo = packageManager.getPackageInfo(
                     applicationPackage,
-                    PackageManager.GET_PERMISSIONS
+                    PackageManager.GET_PERMISSIONS,
                 )
 
                 val applicationName =
@@ -31,7 +31,7 @@ internal object AppInfo {
                         applicationPackage,
                         applicationName,
                         applicationVersion,
-                        requestedPermissions
+                        requestedPermissions,
                     )
             } catch (e: PackageManager.NameNotFoundException) {
                 println("Could not retrieve the app info, $e")
@@ -43,7 +43,7 @@ internal object AppInfo {
         appInfo!!.applicationPackageName?.let {
             appInfoNode.setAttribute(
                 "applicationPackageName",
-                it
+                it,
             )
         }
         appInfo!!.applicationName?.let { appInfoNode.setAttribute("applicationName", it) }
@@ -65,6 +65,6 @@ internal object AppInfo {
         val applicationPackageName: String?,
         val applicationName: String?,
         val applicationVersion: String?,
-        val requestedPermissions: Array<String>?
+        val requestedPermissions: Array<String>?,
     )
 }

--- a/espresso-runner/src/main/kotlin/org/mint/espressoRunner/state/EspressoStateToXML.kt
+++ b/espresso-runner/src/main/kotlin/org/mint/espressoRunner/state/EspressoStateToXML.kt
@@ -62,8 +62,8 @@ object EspressoStateToXML {
                     toXML(
                         doc,
                         view.getChildAt(i),
-                        positionInViewHierarchy.plus(".$i")
-                    )
+                        positionInViewHierarchy.plus(".$i"),
+                    ),
                 )
             }
         }
@@ -76,7 +76,7 @@ object EspressoStateToXML {
     private fun applyResourceAttributes(
         viewElement: Element,
         view: View,
-        positionInViewHierarchy: String
+        positionInViewHierarchy: String,
     ) {
         viewElement.setUserData("origin", view, null)
         viewElement.setAttribute("positionInViewHierarchy", positionInViewHierarchy)
@@ -90,11 +90,11 @@ object EspressoStateToXML {
             try {
                 viewElement.setAttribute(
                     "resourceName",
-                    viewResources.getResourceEntryName(viewId)
+                    viewResources.getResourceEntryName(viewId),
                 )
                 viewElement.setAttribute(
                     "package",
-                    viewResources.getResourcePackageName(viewId)
+                    viewResources.getResourcePackageName(viewId),
                 )
             } catch (e: Resources.NotFoundException) {
                 println("Resource with id=$viewId not found")
@@ -108,14 +108,14 @@ object EspressoStateToXML {
      */
     private fun applyDetailedViewAttributes(
         viewElement: Element,
-        view: View
+        view: View,
     ) {
         ViewAttributes.apply(viewElement, view)
     }
 
     private fun applyWindowAttributes(
         viewElement: Element,
-        view: View
+        view: View,
     ) {
         viewElement.setAttribute("hasWindowFocus", view.hasWindowFocus().toString())
     }

--- a/espresso-runner/src/main/kotlin/org/mint/espressoRunner/state/ExternalIntentDetails.kt
+++ b/espresso-runner/src/main/kotlin/org/mint/espressoRunner/state/ExternalIntentDetails.kt
@@ -12,7 +12,7 @@ import org.w3c.dom.Element
 class ExternalIntentDetails(val node: Element) : VerificationMode {
     override fun verify(
         externalIntentMatcher: Matcher<Intent>,
-        recordedIntents: MutableList<VerifiableIntent>?
+        recordedIntents: MutableList<VerifiableIntent>?,
     ) {
         for (verifiableIntent in recordedIntents!!) {
             val intent = verifiableIntent.intent

--- a/espresso-runner/src/main/kotlin/org/mint/espressoRunner/state/ViewVisibilityPredicate.kt
+++ b/espresso-runner/src/main/kotlin/org/mint/espressoRunner/state/ViewVisibilityPredicate.kt
@@ -11,7 +11,7 @@ class EspressoViewVisibilityPredicate : ViewVisibilityPredicate {
 
     override fun test(v: View): Boolean {
         return ViewMatchers.isDisplayingAtLeast(
-            ESPRESSO_VISIBILITY_THRESHOLD_FOR_ACTIONS
+            ESPRESSO_VISIBILITY_THRESHOLD_FOR_ACTIONS,
         ).matches(v)
     }
 

--- a/espresso-runner/src/main/kotlin/org/mint/espressoRunner/state/attributes/AccessibilityAttributes.kt
+++ b/espresso-runner/src/main/kotlin/org/mint/espressoRunner/state/attributes/AccessibilityAttributes.kt
@@ -23,7 +23,7 @@ internal object AccessibilityAttributes {
         node.setAttribute("labelFor", view.labelFor.toString())
         node.setAttribute(
             "isImportantForAccessibility",
-            view.isImportantForAccessibility.toString()
+            view.isImportantForAccessibility.toString(),
         )
         // for touch target size calculation, minimum 48x48dp is recommended
         // https://developer.android.com/guide/topics/ui/accessibility/apps#large-controls
@@ -73,44 +73,44 @@ internal object AccessibilityAttributes {
             Pair("isPassword", "${accessibilityNodeInfo.isPassword}"),
             Pair("isSelected", "${accessibilityNodeInfo.isSelected}"),
             Pair("isScrollable", "${accessibilityNodeInfo.isScrollable}"),
-            Pair("isVisibleToUser", "${accessibilityNodeInfo.isVisibleToUser}")
+            Pair("isVisibleToUser", "${accessibilityNodeInfo.isVisibleToUser}"),
         )
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             accessibilityAttributes.add(
                 Pair(
                     "isContextClickable",
-                    "${accessibilityNodeInfo.isContextClickable}"
-                )
+                    "${accessibilityNodeInfo.isContextClickable}",
+                ),
             )
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             accessibilityAttributes.add(
                 Pair(
                     "isImportantForAccessibility",
-                    "${accessibilityNodeInfo.isImportantForAccessibility}"
-                )
+                    "${accessibilityNodeInfo.isImportantForAccessibility}",
+                ),
             )
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             accessibilityAttributes.add(
-                Pair("isShowingHintText", "${accessibilityNodeInfo.isShowingHintText}")
+                Pair("isShowingHintText", "${accessibilityNodeInfo.isShowingHintText}"),
             )
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             accessibilityAttributes.add(
-                Pair("isScreenReaderFocusable", "${accessibilityNodeInfo.isScreenReaderFocusable}")
+                Pair("isScreenReaderFocusable", "${accessibilityNodeInfo.isScreenReaderFocusable}"),
             )
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             accessibilityAttributes.add(
-                Pair("isTextEntryKey", "${accessibilityNodeInfo.isTextEntryKey}")
+                Pair("isTextEntryKey", "${accessibilityNodeInfo.isTextEntryKey}"),
             )
         }
 
         node.appendChild(
             "accessibility-node-info",
-            attributes = accessibilityAttributes
+            attributes = accessibilityAttributes,
         )
     }
 }

--- a/espresso-runner/src/main/kotlin/org/mint/espressoRunner/state/attributes/KeyboardAttributes.kt
+++ b/espresso-runner/src/main/kotlin/org/mint/espressoRunner/state/attributes/KeyboardAttributes.kt
@@ -18,7 +18,7 @@ internal object KeyboardAttributes {
             if (!isWindowAdjustableForSoftInput(applicationContext)) {
                 node.setAttribute(
                     "isSoftKeyboardVisible",
-                    isKeyboardVisible(view, applicationContext).toString()
+                    isKeyboardVisible(view, applicationContext).toString(),
                 )
             }
         }
@@ -33,7 +33,7 @@ internal object KeyboardAttributes {
         val marginOfErrorInPx = TypedValue.applyDimension(
             TypedValue.COMPLEX_UNIT_DIP,
             50F,
-            context.resources.displayMetrics
+            context.resources.displayMetrics,
         ).roundToInt()
 
         return heightDiff > marginOfErrorInPx

--- a/espresso-runner/src/main/kotlin/org/mint/espressoRunner/state/attributes/ViewAttributes.kt
+++ b/espresso-runner/src/main/kotlin/org/mint/espressoRunner/state/attributes/ViewAttributes.kt
@@ -173,7 +173,7 @@ object ViewAttributes {
                                         .resources
                                         .configuration
                                         .locale
-                                        .toString()
+                                        .toString(),
                                 )
                             } else {
                                 node.setAttribute(
@@ -184,14 +184,14 @@ object ViewAttributes {
                                         .configuration
                                         .locales
                                         .get(0)
-                                        .toString()
+                                        .toString(),
                                 )
                             }
                         } catch (e: Resources.NotFoundException) {
                             node.setAttribute("locale", "unknown")
                             Log.e(
                                 TAG,
-                                "Failed to retrieve Resource Configuration (Locale). Details: $e"
+                                "Failed to retrieve Resource Configuration (Locale). Details: $e",
                             )
                         }
 

--- a/espresso-runner/src/main/kotlin/org/mint/espressoRunner/state/attributes/ViewGroupAttributes.kt
+++ b/espresso-runner/src/main/kotlin/org/mint/espressoRunner/state/attributes/ViewGroupAttributes.kt
@@ -38,7 +38,7 @@ internal object ViewGroupAttributes {
                 node.setAttribute("isIconified", view.isIconified.toString())
                 node.setAttribute(
                     "isSubmitButtonEnabled",
-                    view.isSubmitButtonEnabled.toString()
+                    view.isSubmitButtonEnabled.toString(),
                 )
             }
             is ViewPager -> {

--- a/espresso-runner/src/main/kotlin/org/mint/espressoRunner/state/attributes/WindowAttributes.kt
+++ b/espresso-runner/src/main/kotlin/org/mint/espressoRunner/state/attributes/WindowAttributes.kt
@@ -20,7 +20,7 @@ object WindowAttributes {
                 (
                     this.flags and WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
                         != WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
-                    ).toString()
+                    ).toString(),
             )
 
             val espressoRoot =

--- a/espresso-runner/src/test/kotlin/org/mint/espressoRunner/matchers/ViewAtPositionTest.kt
+++ b/espresso-runner/src/test/kotlin/org/mint/espressoRunner/matchers/ViewAtPositionTest.kt
@@ -40,8 +40,8 @@ internal class ViewAtPositionTest {
         value = [
             "root.0.1.1",
             "",
-            "root.0.2"
-        ]
+            "root.0.2",
+        ],
     )
     fun noMatches(position: String) {
         val viewAtPositionMatcher = ViewAtPosition(position)

--- a/integration-test-runner/src/main/kotlin/org/mint/integrationTestRunner/ITTestLoop.kt
+++ b/integration-test-runner/src/main/kotlin/org/mint/integrationTestRunner/ITTestLoop.kt
@@ -10,7 +10,7 @@ import org.w3c.dom.Element
 
 open class ITTestLoop(
     private val _ctx: TestCtx,
-    m: TestMetadata = TestMetadata("", "", "")
+    m: TestMetadata = TestMetadata("", "", ""),
 ) : AndroidLoop(_ctx, "1", m) {
     private var stepCount = 1
 
@@ -30,7 +30,7 @@ open class ITTestLoop(
                     ctx.applicationMonitors,
                     listOf(),
                     mapOf(),
-                    setOf()
+                    setOf(),
                 )
             }
         }

--- a/integration-test-runner/src/main/kotlin/org/mint/integrationTestRunner/TestCtx.kt
+++ b/integration-test-runner/src/main/kotlin/org/mint/integrationTestRunner/TestCtx.kt
@@ -23,18 +23,18 @@ data class TestCtx(
     override val applicationMonitors: Set<ApplicationMonitor<*>>,
     val stepState: List<AndroidState>,
     val assertions: Map<Int, Set<XQueryPredicate>>,
-    val invariants: Set<XQueryPredicate>
+    val invariants: Set<XQueryPredicate>,
 ) : AndroidCtx {
     /** Append the given state to the series of states given to the MINT tool */
     fun withStep(state: AndroidState): TestCtx = copy(
-        stepState = stepState + state
+        stepState = stepState + state,
     )
 
     /** Assign a predicate to a given step. Note that we start counting at 1 (for the first step). */
     fun withPredicate(step: Int, predicate: XQueryPredicate): TestCtx = copy(
-        assertions = assertions.plus(Pair(step, assertions.getOrDefaultExt(step, setOf()) + predicate))
+        assertions = assertions.plus(Pair(step, assertions.getOrDefaultExt(step, setOf()) + predicate)),
     )
     fun withInvariant(predicate: XQueryPredicate): TestCtx = copy(
-        invariants = invariants + predicate
+        invariants = invariants + predicate,
     )
 }

--- a/tooling/src/main/kotlin/org/mint/tooling/android/ADBCommand.kt
+++ b/tooling/src/main/kotlin/org/mint/tooling/android/ADBCommand.kt
@@ -45,12 +45,12 @@ object ADBCommand {
                     collectStream(lc.inputStream),
                     collectStream(lc.errorStream),
                     "Command `$cmd` failed (no device connected?)",
-                    exitCode
+                    exitCode,
                 )
             } else {
                 ADBSuccess(
                     collectStream(lc.inputStream),
-                    exitCode
+                    exitCode,
                 )
             }
         } catch (e: Exception) {
@@ -58,7 +58,7 @@ object ADBCommand {
                 "n/a",
                 "n/a",
                 "An exception was thrown: ${e.message}",
-                exitCode
+                exitCode,
             )
         }
     }

--- a/tooling/src/main/kotlin/org/mint/tooling/android/CollectReportingDataTask.kt
+++ b/tooling/src/main/kotlin/org/mint/tooling/android/CollectReportingDataTask.kt
@@ -12,7 +12,7 @@ abstract class CollectReportingDataTask : DefaultTask() {
     @Optional
     @set: Option(
         option = "target",
-        description = "the location of the MINT results"
+        description = "the location of the MINT results",
     )
     var targetDir: String? = null
 

--- a/tooling/src/main/kotlin/org/mint/tooling/android/RenderReportTask.kt
+++ b/tooling/src/main/kotlin/org/mint/tooling/android/RenderReportTask.kt
@@ -18,7 +18,7 @@ open class RenderReportTask : DefaultTask() {
     @set: Option(
         option = "no-pull",
         description = "indicates to skip data retrieval from the device\\n" +
-            "and to use local MINT data found at the default or specified location"
+            "and to use local MINT data found at the default or specified location",
     )
     var noPull = false
 
@@ -26,7 +26,7 @@ open class RenderReportTask : DefaultTask() {
     @Optional
     @set: Option(
         option = "target",
-        description = "the location of the MINT results"
+        description = "the location of the MINT results",
     )
     var targetDir: String? = null
 

--- a/tooling/src/main/kotlin/org/mint/tooling/android/ToolingPlugin.kt
+++ b/tooling/src/main/kotlin/org/mint/tooling/android/ToolingPlugin.kt
@@ -47,15 +47,15 @@ class ToolingPlugin : Plugin<Project> {
                             (any as DirectoryProperty?)?.let {
                                 collectReportingDataTask?.setProperty(
                                     "targetDir",
-                                    it.get().asFile.toString()
+                                    it.get().asFile.toString(),
                                 )
                                 junitReportEnrichingTask?.setProperty(
                                     "junitResults",
-                                    it.get().asFile.toString()
+                                    it.get().asFile.toString(),
                                 )
                                 junitReportEnrichingTask?.setProperty(
                                     "mintResults",
-                                    it.get().asFile.resolve("mint").toString()
+                                    it.get().asFile.resolve("mint").toString(),
                                 )
                             }
                         }
@@ -102,7 +102,7 @@ class ToolingPlugin : Plugin<Project> {
         }
         project.tasks.register(
             JUNIT_REPORT_ENRICHING_TASK,
-            JunitReportEnrichingTask::class.java
+            JunitReportEnrichingTask::class.java,
         )
     }
 

--- a/tooling/src/main/kotlin/org/mint/tooling/android/reporting/ReferenceReportRenderer.kt
+++ b/tooling/src/main/kotlin/org/mint/tooling/android/reporting/ReferenceReportRenderer.kt
@@ -67,7 +67,7 @@ class ReferenceReportRenderer(private val logger: Logger) : ReportRenderer {
                 dir = dir,
                 imgdir = imgdir,
                 session = session,
-                sequences = sutSessionToSequence
+                sequences = sutSessionToSequence,
             ).invoke()
         }
         return dir

--- a/tooling/src/main/kotlin/org/mint/tooling/android/reporting/ReportRenderer.kt
+++ b/tooling/src/main/kotlin/org/mint/tooling/android/reporting/ReportRenderer.kt
@@ -87,8 +87,8 @@ interface ReportRenderer {
             rules.add(
                 Rule(
                     rule.attribute("name")!!,
-                    rule.attribute("description")!!
-                )
+                    rule.attribute("description")!!,
+                ),
             )
         }
         return rules
@@ -104,8 +104,8 @@ interface ReportRenderer {
                 Oracle(
                     oracle.attribute("name")!!,
                     oracle.attribute("description")!!,
-                    oracle.attribute("categories")!!
-                )
+                    oracle.attribute("categories")!!,
+                ),
             )
         }
         return oracles


### PR DESCRIPTION
Because we bump KTLint version from 0.47.1 to 0.48.2, a number of syntactical changes need to be applied in order to comply to de default ruleset:

```
Summary error count (descending) by rule:
  trailing-comma-on-call-site: 232
  trailing-comma-on-declaration-site: 31
  indent: 4
  parameter-list-wrapping: 2
  wrapping: 2
  no-blank-line-before-rbrace: 1
```